### PR TITLE
ログインページのレイアウト変更

### DIFF
--- a/static/css/sp-style.css
+++ b/static/css/sp-style.css
@@ -9,16 +9,6 @@ body {
     -webkit-text-size-adjust: 100%;
 }
 
-.wrapper {
-    width: 100%;
-    background-color: rgb(148, 251, 255);
-}
-
-.header {
-    max-width: 800px;
-    padding: 1px;
-}
-
 .appname {
     padding-left: 2%;
     color: rgb(255, 255, 255);
@@ -99,10 +89,6 @@ hr {
     text-align: center;
 }
 
-.signup-form {
-    text-align: center;
-}
-
 .rival-inline {
     text-align: center;
 }
@@ -115,8 +101,27 @@ hr {
     text-align: center;
 }
 
-.footer{
-    margin: auto;
-    max-width: 800px;
-    padding: 10px;
+.bd-callout {
+    padding: 1.25rem;
+    margin-top: 1.25rem;
+    margin-bottom: 1.25rem;
+    border: 1px solid #e9ecef;
+    border-left-width: .25rem;
+    border-radius: .25rem;
+}
+
+.bd-callout-info {
+    border-left-color: #5bc0de;
+}
+
+.bd-callout-warning {
+    border-left-color: #f0ad4e;
+}
+
+.bd-callout-danger {
+    border-left-color: #d9534f;
+}
+
+.form-control {
+    width: initial;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -9,16 +9,6 @@ body {
     -webkit-text-size-adjust: 100%;
 }
 
-.wrapper {
-    width: 100%;
-    background-color: rgb(148, 251, 255);
-}
-
-.header {
-    max-width: 800px;
-    padding: 1px;
-}
-
 .appname {
     padding-left: 2%;
     color: rgb(255, 255, 255);
@@ -108,8 +98,31 @@ hr {
     text-align: center;
 }
 
-.footer{
-    margin: auto;
-    max-width: 800px;
-    padding: 10px;
+.bd-callout+.bd-callout {
+    margin-top: -.25rem;
+}
+
+.bd-callout {
+    padding: 1.25rem;
+    margin-top: 1.25rem;
+    margin-bottom: 1.25rem;
+    border: 1px solid #e9ecef;
+    border-left-width: .25rem;
+    border-radius: .25rem;
+}
+
+.bd-callout-info {
+    border-left-color: #5bc0de;
+}
+
+.bd-callout-warning {
+    border-left-color: #f0ad4e;
+}
+
+.bd-callout-danger {
+    border-left-color: #d9534f;
+}
+
+.form-control {
+    width: initial;
 }

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="ja">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="description" content="">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <link rel="stylesheet" media="screen and (max-width:768px)" href="{{ url_for('static', filename = 'css/sp-style.css') }}">
+        <link rel="stylesheet" media="screen and (min-width:769px)" href="{{ url_for('static', filename = 'css/style.css') }}">
+        <title>SDVX-EXスコアツール</title>
+    </head>
+    <body>
+        <header class="site-header wrapper">
+            <div class="header">
+                <a href="/" class="appname">SDVX-EXスコアツール</a>
+            </div>
+        </header>
+
+        {%- block content %}{% endblock %}
+
+        <footer class="site-footer wrapper">
+            <div class="footer">
+            </div>
+        </footer>
+    </body>
+</html>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -5,21 +5,30 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-giJF6kkoqNQ00vy+HMDP7azOuL0xtbfIcaT9wjKHr8RbDVddVHyTfAAsrekwKmP1" crossorigin="anonymous">
         <link rel="stylesheet" media="screen and (max-width:768px)" href="{{ url_for('static', filename = 'css/sp-style.css') }}">
         <link rel="stylesheet" media="screen and (min-width:769px)" href="{{ url_for('static', filename = 'css/style.css') }}">
         <title>SDVX-EXスコアツール</title>
     </head>
     <body>
-        <header class="site-header wrapper">
-            <div class="header">
-                <a href="/" class="appname">SDVX-EXスコアツール</a>
-            </div>
+        <header>
+            <nav class="navbar navbar-dark bg-primary">
+                <div class="container-fluid">
+                    <a class="navbar-brand" href="/">SDVX-EXスコアツール</a>
+                    <div class="navbar-nav ms-auto">
+                        <!-- 未ログイン時とログイン時で表示する内容を分けたいです。 -->
+                        <!-- 未ログイン時は使い方のリンク -->
+                        <a class="nav-link active" href="{{url_for('manual')}}">使い方</a>
+                        <!-- ログイン時はマイページにあるリンク集、ログアウトなど -->
+                    </div>
+                </div>
+            </nav>
         </header>
 
         {%- block content %}{% endblock %}
 
-        <footer class="site-footer wrapper">
-            <div class="footer">
+        <footer class="footer bg-primary">
+            <div class="container">
             </div>
         </footer>
     </body>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,20 +1,5 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" media="screen and (max-width:768px)" href="{{ url_for('static', filename = 'css/sp-style.css') }}">
-    <link rel="stylesheet" media="screen and (min-width:769px)" href="{{ url_for('static', filename = 'css/style.css') }}">
-    <title>SDVX-EXスコアツール</title>
-</head>
-<body>
-    <header class="site-header wrapper">
-        <div class="header">
-            <a href="/" class="appname">SDVX-EXスコアツール</a>
-        </div>
-    </header>
+{%- extends "layout.html" %}
+{%- block content %}
     <div class="login-form">
         <form action="/login/try" method="POST"
                 class="pure-form pure-form-stacked">
@@ -48,9 +33,4 @@
         引き続き、本サービスをよろしくお願いいたします。
     </p>
     <hr>
-    <footer class="site-footer wrapper">
-        <div class="footer">
-        </div>
-    </footer>
-</body>
-</html>
+{%- endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,36 +1,38 @@
 {%- extends "layout.html" %}
 {%- block content %}
-    <div class="login-form">
-        <form action="/login/try" method="POST"
-                class="pure-form pure-form-stacked">
-            <legend>ログインしてください</legend>
-            <fieldset>
-                <label for="user">ユーザーID</label>
-                <input type="text" name="user" id="user"><br/>
-                <label for="pw">パスワード</label>
-                <input type="password" name="pw" id="pw"><br/>
-                <button type="submit"
-                        class="pure-button pure-button-primary">
-                    ログイン</button>
-            </fieldset>
+    <div class="login-form container">
+        <div class="bd-callout bd-callout-warning">
+            ログインしてください
+        </div>
+
+        <form action="/login/try" method="POST">
+            <div class="mb-3">
+              <label for="user" class="form-label">ユーザーID</label>
+              <input type="text" name="user" id="user" class="form-control">
+            </div>
+            <div class="mb-3">
+              <label for="pw" class="form-label">パスワード</label>
+              <input type="password" class="form-control" id="pw">
+            </div>
+            <button type="submit" class="btn btn-primary">ログイン</button>
+            <a href="{{url_for('signup')}}" class="btn btn-success">新規登録はこちらから</a>
         </form>
+        
+        <hr>
+
+        <div class="card">
+            <h3 class="card-header">【重要】更新などのお知らせ</h3>
+            <div class="card-body">
+                <p class="card-text">
+                    今後につきましては、主にTwitterの本サービスの運営用アカウント(<a href="https://twitter.com/sdvx_EXtool">@sdvx_EXtool</a>)からお知らせいたします。
+                    そのため、Twitterアカウントをお持ちの方は、こちらのアカウントをフォローしていただけると幸いです。
+                </p>
+                <p class="card-text">
+                    また、スコア登録時において、以前では私の楽曲データに存在しない楽曲がスコアデータに含まれる際にエラーとなる仕様でしたが、
+                    今回の更新から、その際にエラーになることを回避して、その楽曲の情報を「今回のEXスコア更新」ページにて記載する仕様に変更いたしました。
+                    以前の仕様が原因で、本サービスを利用してくださっている方々には大変ご迷惑をお掛けいたしました、申し訳ありません。
+                    引き続き、本サービスをよろしくお願いいたします。
+                </p>
+          </div>
     </div>
-    <div class="signup-form">
-        <a href="{{url_for('signup')}}" class="button">新規登録はこちらから</a>
-        <a href="{{url_for('manual')}}" class="button">使い方</a>
-    </div>
-    <hr>
-    <h2>更新などのお知らせ</h2>
-    <p>
-        [重要]今後のお知らせにつきましては、主にTwitterの本サービスの運営用アカウント(<a href="https://twitter.com/sdvx_EXtool">@sdvx_EXtool</a>)
-        からお知らせいたします。そのため、Twitterアカウントをお持ちの方は、こちらのアカウントをフォローしていただけると幸いです。
-    </p>
-    <p>
-        また、スコア登録時において、以前では私の楽曲データに存在しない楽曲がスコアデータに含まれる際にエラーとなる仕様でしたが、
-        今回の更新から、その際にエラーになることを回避して、その楽曲の情報を「今回のEXスコア更新」ページにて記載する仕様に変更いたしました。
-        以前の仕様が原因で、本サービスを利用してくださっている方々には大変ご迷惑をお掛けいたしました、申し訳ありません。
-        そして、レイアウトを一部変更いたしました。
-        引き続き、本サービスをよろしくお願いいたします。
-    </p>
-    <hr>
 {%- endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -12,7 +12,7 @@
             </div>
             <div class="mb-3">
               <label for="pw" class="form-label">パスワード</label>
-              <input type="password" class="form-control" id="pw">
+              <input type="password" name="pw" id="pw" class="form-control">
             </div>
             <button type="submit" class="btn btn-primary">ログイン</button>
             <a href="{{url_for('signup')}}" class="btn btn-success">新規登録はこちらから</a>

--- a/templates/logout.html
+++ b/templates/logout.html
@@ -1,20 +1,5 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" media="screen and (max-width:768px)" href="{{ url_for('static', filename = 'css/sp-style.css') }}">
-    <link rel="stylesheet" media="screen and (min-width:769px)" href="{{ url_for('static', filename = 'css/style.css') }}">
-    <title>SDVX-EXスコアツール</title>
-</head>
-<body>
-    <header class="site-header wrapper">
-        <div class="header">
-            <a href="/" class="appname">SDVX-EXスコアツール</a>
-        </div>
-    </header>
+{%- extends "layout.html" %}
+{%- block content %}
     <div class="logout-form">
         <p>ログアウトしますか？</p>
         <div class="inline">
@@ -22,12 +7,6 @@
             <a href="{{url_for('index')}}" class="button">いいえ</a>
         </div>
     </div>
-    <hr>
 
     <hr>
-    <footer class="site-footer wrapper">
-        <div class="footer">
-        </div>
-    </footer>
-</body>
-</html>
+{%- endblock %}

--- a/templates/logout.html
+++ b/templates/logout.html
@@ -1,12 +1,12 @@
 {%- extends "layout.html" %}
 {%- block content %}
-    <div class="logout-form">
-        <p>ログアウトしますか？</p>
+    <div class="login-form container">
+        <div class="bd-callout bd-callout-warning">
+            ログアウトしますか？
+        </div>
         <div class="inline">
-            <a href="{{url_for('try_logout')}}" class="button">はい</a>
-            <a href="{{url_for('index')}}" class="button">いいえ</a>
+            <a href="{{url_for('try_logout')}}" class="btn btn-success">はい</a>
+            <a href="{{url_for('index')}}" class="btn btn-secondary">いいえ</a>
         </div>
     </div>
-
-    <hr>
 {%- endblock %}


### PR DESCRIPTION
close #5 

-  PC
<img width="1440" alt="スクリーンショット 2021-10-13 22 47 34" src="https://user-images.githubusercontent.com/40511624/137148404-31ac5748-6047-42cd-b2fc-ff5131f14265.png">

- モバイル
<img width="380" alt="スクリーンショット 2021-10-13 22 48 26" src="https://user-images.githubusercontent.com/40511624/137148450-64a17c9c-6ffc-4543-8eb5-9f399f259f31.png"> 

## やったこと
- bootstrap5.0導入
- layout.html作成
  - ヘッダーとフッターを共通化するためのhtmlファイルです。
- login.htmlのレイアウト変更
  - 使い方リンクをヘッダー内に移動しました。 
- logout.htmlのレイアウト変更  
  - こちらについて[コメント](https://github.com/reiyiyi/SDVX-EXScoreTool/issues/5#issuecomment-942333317)しました。

## 確認してほしいこと
- [x] reiyiyi さんのローカル環境で適切に表示されるか確認をお願いします。
  - `git pull origin UI-fix/#5-login,logout` 
- [x] layout.html 内の[コメントアウト](https://github.com/reiyiyi/SDVX-EXScoreTool/pull/17/files#diff-4d25ecf848b3aef11a6e80ba6a200937e2999e7699c735db7bccdc2a9d07c48eR19-R22)について確認をお願いします。
- [x] その他、レイアウトやコードに違和感や問題がないか確認をお願いします。