### PR TITLE
マニュアルページのレイアウト修正

### DIFF
--- a/static/css/sp-style.css
+++ b/static/css/sp-style.css
@@ -130,3 +130,7 @@ hr {
     flex: initial;
     width: initial;
 }
+
+.title {
+    margin: 1rem;
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -131,3 +131,7 @@ hr {
     flex: initial;
     width: initial;
 }
+
+.title {
+    margin: 1rem;
+}

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -25,6 +25,9 @@
             </nav>
         </header>
 
+        <!-- JavaScript Bundle with Popper -->
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-ygbV9kiqUc6oa4msXn9868pTtWMgiQaeYH7/t7LECLbyPA2x65Kgf80OJFdroafW" crossorigin="anonymous"></script>
+
         {%- block content %}{% endblock %}
 
         <footer class="footer bg-primary">

--- a/templates/manual.html
+++ b/templates/manual.html
@@ -1,124 +1,213 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" media="screen and (max-width:768px)" href="{{ url_for('static', filename = 'css/sp-style.css') }}">
-    <link rel="stylesheet" media="screen and (min-width:769px)" href="{{ url_for('static', filename = 'css/style.css') }}">
-    <title>SDVX-EXスコアツール</title>
-</head>
-<body>
-    <header class="site-header wrapper">
-        <div class="header">
-            <a href="/" class="appname">SDVX-EXスコアツール</a>
+{%- extends "layout.html" %}
+{%- block content %}
+    <div id="manual" class="container">
+        <h1 class="title">使い方</h1>
+        <div class="accordion" id="howto">
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingOne">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
+                        アカウント作成
+                    </button>
+                </h2>
+                <div id="collapseOne" class="accordion-collapse collapse" aria-labelledby="headingOne" data-bs-parent="#howto">
+                    <div class="accordion-body">
+                        <p>
+                            ログインページの「<a href="/login/signup">新規登録はこちらから</a>」から、アカウント作成を行なってください。
+                        </p>
+                        <p>
+                            新規登録時に入力していただいたユーザーIDとパスワードはログイン時に必要となるため、大切に保管してください。
+                        </p>
+                        <p>
+                            また、ユーザーIDで用いることのできる文字は英数字とアンダーバー(_)のみであり、1文字以上16文字以下にしてください。
+                            パスワードは4文字以上にしてください。
+                            なお、これらは後から変更することはできないため、ご注意ください。特にユーザーIDは好敵手などで他の方も閲覧することができるため、その点もご注意ください。
+                        </p>
+                        <p>
+                            アカウント作成後は、「設定」からユーザー名の変更を行なうことを推奨します。初期状態では、ユーザーIDとなっています。
+                            ただし、現時点でユーザー名で用いることのできる文字は英数字とアンダーバー(_)のみです。そして、ユーザー名も1文字以上16文字以下にしてください。
+                        </p>
+                    </div>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingTwo">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
+                        スコア登録
+                    </button>
+                </h2>
+                <div id="collapseTwo" class="accordion-collapse collapse" aria-labelledby="headingTwo" data-bs-parent="#howto">
+                    <div class="accordion-body">
+                        <p>
+                            スコア登録には、CSVファイルを使用するため<b>e-amusement プレミアムコースの加入[550円/月(税込)]</b>が必要です。
+                        </p>
+                        <p>
+                            「SOUND VOLTEX EXCEED GEAR」公式サイトの「PLAY DATA」→「スコアデータ/CSVダウンロード」からスコアデータをコピーした後、本サービスの「<a href="/resister">スコア登録</a>」から、先ほどコピーしたスコアデータをペーストし、「送信」をクリックすることで、スコア登録を行なうことができます。
+                            その際、今回のスコア登録でEXスコアを更新した譜面の情報と更新前後のEXスコアを確認することができます。ただし、記載することができる譜面の情報などは100件までです、ご了承ください。
+                        </p>
+                        <p>
+                            スコア登録時に「今回のEXスコア更新」にて何も表示されることがない場合がありますが、「今回のEXスコア更新」のページに遷移した場合は正常にスコアデータは登録されていますのでご安心ください。
+                        </p>
+                        <p>
+                            また、本サービスにおける新曲データの追加状況や予期せぬ公式による一部の楽曲名の変更などにより、一部の譜面において正常にスコアデータが登録されない場合があります。
+                            その場合は「今回のEXスコア更新」のページにてその譜面の情報(最大100件)を記載させていただきます。そして、私もデータ修正のためにその譜面の情報について取得することができるようにしております、ご了承ください。
+                        </p>
+                    </div>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingThree">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
+                        更新スコア確認
+                    </button>
+                </h2>
+                <div id="collapseThree" class="accordion-collapse collapse" aria-labelledby="headingThree" data-bs-parent="#howto">
+                    <div class="accordion-body">
+                        <p>
+                            本サービスの「<a href="/hiscore">更新スコア確認</a>」から、直近のEXスコアを更新した譜面の情報と更新前後のEXスコアを確認することができます。
+                            ただし、こちらも記載することができる譜面の情報などは100件までです、ご了承ください。
+                        </p>
+                    </div>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingFour">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseFour" aria-expanded="false" aria-controls="collapseFour">
+                        スコア確認
+                    </button>
+                </h2>
+                <div id="collapseFour" class="accordion-collapse collapse" aria-labelledby="headingFour" data-bs-parent="#howto">
+                    <div class="accordion-body">
+                        <p>
+                            本サービスの「<a href="/myscore">スコア確認</a>」からレベルを選択することで、そのレベルの譜面における自分のEXスコアを確認することができます。
+                        </p>
+                    </div>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingFive">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseFive" aria-expanded="false" aria-controls="collapseFive">
+                        ランキング
+                    </button>
+                </h2>
+                <div id="collapseFive" class="accordion-collapse collapse" aria-labelledby="headingFive" data-bs-parent="#howto">
+                    <div class="accordion-body">
+                        <p>
+                            本サービスの「スコア確認」の「ランキングへ」から、譜面ごとに本サービス利用者の中でのランキングを確認することができます。
+                        </p>
+                        <p>
+                            また、ランキングに記載されるユーザー名から、そのアカウントのユーザーページにアクセスすることができます。
+                            現時点では上位100位まで記載しています。なお、スコア公開設定を非公開に設定している方がランキングに入っている場合、その方に関しては
+                            ユーザー名を「[SECRET]」と置き換えています。また、記載されるランキングは日付が変わるタイミング(午前0時)で自動的に更新されます。スコア登録と同時に更新されるものではないため、ご了承ください。
+                        </p>
+                    </div>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingSix">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseSix" aria-expanded="false" aria-controls="collapseSix">
+                        武器曲
+                    </button>
+                </h2>
+                <div id="collapseSix" class="accordion-collapse collapse" aria-labelledby="headingSix" data-bs-parent="#howto">
+                    <div class="accordion-body">
+                        <p>
+                            本サービスの「<a href="/strengths">武器曲</a>」から、他の本サービス利用者と比べてEXスコアが上位に位置している譜面を確認することができます。
+                        </p>
+                        <p>
+                            この際、記載される譜面に関するデータは上位〇〇%の数字が小さい順に並んでおり、現時点では多めに300件まで記載しています。
+                            また、ここで記載される情報は日付が変わるタイミング(午前0時)で自動的に更新されます。こちらもスコア登録と同時に更新されるものではないため、ご了承ください。
+                            今後ではレベルで譜面を絞り込む機能や、上位〇〇%の数字が大きい順に並び替える機能の追加を考えております。
+                        </p>
+                        <p>
+                            そして、本サービスは仮公開されてから間もないために登録されているスコアデータが不足しており、現時点ではあまりこの機能が機能していない状態です。
+                            そのため、是非ともスコア登録にご協力お願いいたします。
+                        </p>
+                    </div>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingSeven">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseSeven" aria-expanded="false" aria-controls="collapseSeven">
+                        通知
+                    </button>
+                </h2>
+                <div id="collapseSeven" class="accordion-collapse collapse" aria-labelledby="headingSeven" data-bs-parent="#howto">
+                    <div class="accordion-body">
+                        <p>
+                            本サービスにおいて自分が好敵手登録している方が、ある譜面でEXスコアを更新し、自分のEXスコア以下から自分のEXスコア以上となった場合、
+                            本サービスの「<a href="/notice">通知</a>」から、その譜面の情報と好敵手の更新前後のEXスコアなどを通知として送られ、確認することができます。
+                        </p>
+                        <p>
+                            ただし、好敵手がスコア公開設定を非公開に設定していた場合、その方からにおいては通知が送られることはありません。
+                            また、自分のEXスコアが0である譜面においても、通知が送られることはありません。
+                            そして、こちらも記載することができる譜面の情報などは直近の100件までです、ご了承ください。
+                        </p>
+                    </div>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingEight">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseEight" aria-expanded="false" aria-controls="collapseEight">
+                        好敵手
+                    </button>
+                </h2>
+                <div id="collapseEight" class="accordion-collapse collapse" aria-labelledby="headingEight" data-bs-parent="#howto">
+                    <div class="accordion-body">
+                        <p>
+                            本サービスの「<a href="/rival">好敵手</a>」から、好敵手の設定状況の確認やユーザー検索を行なうことができます。現時点では、好敵手に設定することができるアカウントの数の上限はありません。
+                        </p>
+                    </div>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingNine">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseNine" aria-expanded="false" aria-controls="collapseNine">
+                        設定
+                    </button>
+                </h2>
+                <div id="collapseNine" class="accordion-collapse collapse" aria-labelledby="headingNine" data-bs-parent="#howto">
+                    <div class="accordion-body">
+                        <p>
+                            本サービスの「<a href="/settings">設定</a>」から、ユーザー名の変更やスコア公開設定の変更を行なうことができます。
+                        </p>
+                        <p>
+                            スコア公開設定を非公開にした場合、ランキングに自分のユーザー名が記載されることやユーザーページにS-PUC数が記載されること、自分のスコア更新による逆好敵手への通知が送られることがなくなります。
+                            投げ合いの大会などが控えていて「誰かにスコアや詰めている譜面を知られたくない」などの理由が無い場合は、基本的には公開に設定することを推奨します。
+                        </p>
+                    </div>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingTen">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTen" aria-expanded="false" aria-controls="collapseTen">
+                        新曲データ追加について
+                    </button>
+                </h2>
+                <div id="collapseTen" class="accordion-collapse collapse" aria-labelledby="headingTen" data-bs-parent="#howto">
+                    <div class="accordion-body">
+                        <p>
+                            本サービスでは新曲データの追加を半手動で行なっています。
+                            そのため、こちらが新曲データの追加を行なう前にその新曲のスコアが記載されたスコアデータを登録した場合、その譜面につきましてはスコアデータが登録されません、ご了承ください。
+                        </p>
+                    </div>
+                </div>
+            </div>
+            <div class="accordion-item">
+                <h2 class="accordion-header" id="headingEleven">
+                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseEleven" aria-expanded="false" aria-controls="collapseEleven">
+                        問い合わせ先
+                    </button>
+                </h2>
+                <div id="collapseEleven" class="accordion-collapse collapse" aria-labelledby="headingEleven" data-bs-parent="#howto">
+                    <div class="accordion-body">
+                        <p>
+                            もしも何か不具合等がありましたら、<a href="https://twitter.com/Re_gi_A">@Re_gi_A</a>までご連絡いただけると幸いです。
+                        </p>
+                    </div>
+                </div>
+            </div>
         </div>
-    </header>
-    <h2>SDVX-EXスコアツールの使い方や概要</h2>
-    <hr>
-    <div class="manual">
-        <h3>[重要]本サービスを使うために必要なこと</h3>
-        <li>本サービスのアカウント作成</li>
-        <li>e-amusement プレミアムコース加入[550円/月(税込)]</li>
-
-        <h3>アカウント作成について</h3>
-        <p>
-            ログインページの「新規登録はこちらから」から、アカウント作成を行なってください。
-            新規登録時に入力していただいたユーザーIDとパスワードはログイン時に必要となるため、大切に保管してください。
-        </p>
-        <p>
-            また、ユーザーIDで用いることのできる文字は英数字とアンダーバー(_)のみであり、1文字以上16文字以下にしてください。
-            パスワードは4文字以上にしてください。
-            なお、これらは後から変更することはできないため、ご注意ください。特にユーザーIDは好敵手などで他の方も閲覧することができるため、その点もご注意ください。
-        </p>
-        <p>
-            アカウント作成後は、「設定」からユーザー名の変更を行なうことを推奨します。初期状態では、ユーザーIDとなっています。
-            ただし、現時点でユーザー名で用いることのできる文字は英数字とアンダーバー(_)のみです。そして、ユーザー名も1文字以上16文字以下にしてください。
-        </p>
-
-        <h3>スコア登録について</h3>
-        <p>
-            まず「SOUND VOLTEX EXCEED GEAR」公式サイトの「PLAY DATA」→「スコアデータ/CSVダウンロード」からスコアデータをコピーした後、本サービスの「スコア登録」から、先ほどコピーしたスコアデータをペーストし、「送信」をクリックすることで、スコア登録を行なうことができます。
-            その際、今回のスコア登録でEXスコアを更新した譜面の情報と更新前後のEXスコアを確認することができます。ただし、記載することができる譜面の情報などは100件までです、ご了承ください。
-        </p>
-        <p>
-            スコア登録時に「今回のEXスコア更新」にて何も表示されることがない場合がありますが、「今回のEXスコア更新」のページに遷移した場合は正常にスコアデータは登録されていますのでご安心ください。
-        </p>
-        <p>
-            また、本サービスにおける新曲データの追加状況や予期せぬ公式による一部の楽曲名の変更などにより、一部の譜面において正常にスコアデータが登録されない場合があります。
-            その場合は「今回のEXスコア更新」のページにてその譜面の情報(最大100件)を記載させていただきます。そして、私もデータ修正のためにその譜面の情報について取得することができるようにしております、ご了承ください。
-        </p>
-        <h3>更新スコア確認について</h3>
-        <p>
-            本サービスの「更新スコア確認」から、直近のEXスコアを更新した譜面の情報と更新前後のEXスコアを確認することができます。
-            ただし、こちらも記載することができる譜面の情報などは100件までです、ご了承ください。
-        </p>
-        <h3>スコア確認について</h3>
-        <p>
-            本サービスの「スコア確認」からレベルを選択することで、そのレベルの譜面における自分のEXスコアを確認することができます。
-        </p>
-        <h3>ランキングについて</h3>
-        <p>
-            本サービスの「スコア確認」の「ランキングへ」から、譜面ごとに本サービス利用者の中でのランキングを確認することができます。
-            また、ランキングに記載されるユーザー名から、そのアカウントのユーザーページにアクセスすることができます。
-            現時点では上位100位まで記載しています。なお、スコア公開設定を非公開に設定している方がランキングに入っている場合、その方に関しては
-            ユーザー名を「[SECRET]」と置き換えています。また、記載されるランキングは日付が変わるタイミング(午前0時)で自動的に更新されます。スコア登録と同時に更新されるものではないため、ご了承ください。
-        </p>
-        <h3>武器曲について</h3>
-        <p>
-            本サービスの「武器曲」から、他の本サービス利用者と比べてEXスコアが上位に位置している譜面を確認することができます。
-            この際、記載される譜面に関するデータは上位〇〇%の数字が小さい順に並んでおり、現時点では多めに300件まで記載しています。
-            また、ここで記載される情報は日付が変わるタイミング(午前0時)で自動的に更新されます。こちらもスコア登録と同時に更新されるものではないため、ご了承ください。
-            今後ではレベルで譜面を絞り込む機能や、上位〇〇%の数字が大きい順に並び替える機能の追加を考えております。
-        </p>
-        <p>
-            そして、本サービスは仮公開されてから間もないために登録されているスコアデータが不足しており、現時点ではあまりこの機能が機能していない状態です。
-            そのため、是非ともスコア登録にご協力お願いいたします。
-        </p>
-        <h3>通知について</h3>
-        <p>
-            本サービスにおいて自分が好敵手登録している方が、ある譜面でEXスコアを更新し、自分のEXスコア以下から自分のEXスコア以上となった場合、
-            本サービスの「通知」から、その譜面の情報と好敵手の更新前後のEXスコアなどを通知として送られ、確認することができます。
-            ただし、好敵手がスコア公開設定を非公開に設定していた場合、その方からにおいては通知が送られることはありません。
-            また、自分のEXスコアが0である譜面においても、通知が送られることはありません。
-            そして、こちらも記載することができる譜面の情報などは直近の100件までです、ご了承ください。
-        </p>
-        <h3>好敵手について</h3>
-        <p>
-            本サービスの「好敵手」から、好敵手の設定状況の確認やユーザー検索を行なうことができます。現時点では、好敵手に設定することができるアカウントの数の上限はありません。
-        </p>
-        <h3>設定について</h3>
-        <p>
-            本サービスの「設定」から、ユーザー名の変更やスコア公開設定の変更を行なうことができます。
-            スコア公開設定を非公開にした場合、ランキングに自分のユーザー名が記載されることやユーザーページにS-PUC数が記載されること、自分のスコア更新による逆好敵手への通知が送られることがなくなります。
-            投げ合いの大会などが控えていて「誰かにスコアや詰めている譜面を知られたくない」などの理由が無い場合は、基本的には公開に設定することを推奨します。
-        </p>
-        <h3>新曲データ追加について</h3>
-        <p>ご了承ください。
-        </p>
-            本サービスでは新曲データの追加を半手動で行なっています。
-            そのため、こちらが新曲データの追加を行なう前にその新曲のスコアが記載されたスコアデータを登録した場合、その譜面につきましてはスコアデータが登録されません、ご了承ください。
-        <h3>問い合わせ先</h3>
-        <p>
-            もしも何か不具合等がありましたら、<a href="https://twitter.com/Re_gi_A">@Re_gi_A</a>までご連絡いただけると幸いです。
-        </p>
-        <h3>この先の本サービスのアップデートについて</h3>
-        <p>
-            現時点では、本サービスのレイアウトの変更を考えております。
-            是非とも本サービス、「SDVX-EXスコアツール」をよろしくお願いいたします。
-        </p>
         <hr>
-        <p>
-            <p>developed by <a href="https://twitter.com/Re_gi_A">@Re_gi_A</a></p>
-        </p>
+        <p>developed by <a href="https://twitter.com/Re_gi_A">@Re_gi_A</a></p>
     </div>
-    <hr>
-
-    <footer class="site-footer wrapper">
-        <div class="footer">
-        </div>
-        <hr>
-    </footer>
-</body>
-</html>
+{%- endblock %}


### PR DESCRIPTION
#6 

## スクリーンショット
- PC
<img width="1440" alt="スクリーンショット 2021-10-31 22 38 06" src="https://user-images.githubusercontent.com/40511624/139586459-a66178d4-2167-4f12-a157-f2fd54e60004.png">
<img width="1440" alt="スクリーンショット 2021-10-31 22 38 15" src="https://user-images.githubusercontent.com/40511624/139586465-3ed01957-434a-45b9-9233-248444ae3d75.png">

- モバイル
<img width="377" alt="スクリーンショット 2021-10-31 22 37 19" src="https://user-images.githubusercontent.com/40511624/139586471-ec0b8156-c6d1-4717-a7eb-6f09996096c3.png">
<img width="377" alt="スクリーンショット 2021-10-31 22 37 38" src="https://user-images.githubusercontent.com/40511624/139586478-12a1aaa3-a648-4ee5-a733-fb1678c387a0.png">

## 修正した点
- 文面修正
- 一部リンク追加
- レイアウト修正

## レビュー項目
- [x] reiyiyi さんの環境で正しく動作されるか確認をお願いします。
- [x] その他、コードや文面に違和感がないか確認をお願いします。