### PR TITLE
settings画面のレイアウト修正

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,40 +1,33 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" media="screen and (max-width:768px)" href="{{ url_for('static', filename = 'css/sp-style.css') }}">
-    <link rel="stylesheet" media="screen and (min-width:769px)" href="{{ url_for('static', filename = 'css/style.css') }}">
-    <title>SDVX-EXスコアツール</title>
-</head>
-<body>
-    <header class="site-header wrapper">
-        <div class="header">
-            <a href="/" class="appname">SDVX-EXスコアツール</a>
-        </div>
-    </header>
-    <p>設定</p>
-    <div class="settings">
+{%- extends "layout.html" %}
+{%- block content %}
+    <div id="settings" class="container">
+        <h1 class="title">設定</h1>
+
         <form action="/settings/change" method="POST">
-            <p>ユーザー名</p>
-            <input type="text" name="new-user-name" id="new-user-name" value={{user_name}}>
-            <p>スコア公開設定</p>
-            <input type="radio" name="score-setting" id="score-setting" value="yes" {{true_checked}}>公開
-            <input type="radio" name="score-setting" id="score-setting" value="no" {{false_checked}}>非公開
-            <br/>
-            <button type="submit"
-                    class="pure-button pure-button-primary">
-                更新</button>
+            <div class="mb-3">
+                <label for="user" class="form-label">ユーザー名</p>
+                <input type="text" class="form-control" name="new-user-name" id="new-user-name" value={{user_name}}>
+                <div id="userHelpBlock" class="form-text">
+                    1~16文字以下、英数字とアンダーバー(_)のみ使用可能。
+                </div>        
+            </div>
+
+            <div class="mb-3">
+                <label for="user" class="form-label">スコア公開設定</p>
+                <div class="form-check">
+                    <input class="form-check-input" type="radio" name="score-setting" id="score-setting" value="yes" {{true_checked}}>
+                    <label class="form-check-label" for="flexRadioDefault1">
+                        公開
+                    </label>
+                </div>
+                <div class="form-check">
+                    <input class="form-check-input" type="radio" name="score-setting" id="score-setting" value="no" {{false_checked}}>
+                    <label class="form-check-label" for="flexRadioDefault2">
+                        非公開 
+                    </label>
+                </div>            </div>
+
+            <button type="submit" class="btn btn-primary">更新</button>
         </form>
     </div>
-    <hr>
-
-    <hr>
-    <footer class="site-footer wrapper">
-        <div class="footer">
-        </div>
-    </footer>
-</body>
-</html>
+{%- endblock %}

--- a/templates/settings_error.html
+++ b/templates/settings_error.html
@@ -1,30 +1,9 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" media="screen and (max-width:768px)" href="{{ url_for('static', filename = 'css/sp-style.css') }}">
-    <link rel="stylesheet" media="screen and (min-width:769px)" href="{{ url_for('static', filename = 'css/style.css') }}">
-    <title>SDVX-EXスコアツール</title>
-</head>
-<body>
-    <header class="site-header wrapper">
-        <div class="header">
-            <a href="/" class="appname">SDVX-EXスコアツール</a>
+{%- extends "layout.html" %}
+{%- block content %}
+    <div class="container">
+        <div class="bd-callout bd-callout-danger">
+            エラー:{{mode}}
         </div>
-    </header>
-    <div class="error">
-        <p>エラー:{{mode}}</p>
-        <a href="{{url_for('settings')}}" class="button">設定画面へ戻る</a>
+        <a href="{{url_for('settings')}}" class="btn btn-secondary">設定画面へ戻る</a>
     </div>
-    <hr>
-
-    <hr>
-    <footer class="site-footer wrapper">
-        <div class="footer">
-        </div>
-    </footer>
-</body>
-</html>
+{%- endblock %}


### PR DESCRIPTION
close #8 

### PC
- settings.html
<img width="1434" alt="スクリーンショット 2021-11-12 21 41 51" src="https://user-images.githubusercontent.com/40511624/141469637-4262f5a8-2c96-445f-8ec5-ed20b3baabde.png">

- settings_error.html
<img width="1440" alt="スクリーンショット 2021-11-12 21 44 05" src="https://user-images.githubusercontent.com/40511624/141469655-bf4996dd-8fe1-4c6b-a6d7-5dfd224addcf.png">

### モバイル
- settings.html
<img width="375" alt="スクリーンショット 2021-11-12 21 42 10" src="https://user-images.githubusercontent.com/40511624/141469674-2f445076-35cc-46e8-8427-771de7d6a9f2.png">

- settings_error.html
<img width="376" alt="スクリーンショット 2021-11-12 21 44 17" src="https://user-images.githubusercontent.com/40511624/141469685-99dd41f6-fa49-479b-ac35-7be344a5847c.png">

## やったこと
- レイアウト変更

## 確認してほしいこと
- [x] reiyiyi さんのローカル環境で適切に表示されるか確認をお願いします。
- [x] その他、レイアウトやコードに違和感や問題がないか確認をお願いします。