### PR TITLE
resister.htmlのレイアウト修正

### DIFF
--- a/static/css/sp-style.css
+++ b/static/css/sp-style.css
@@ -122,10 +122,6 @@ hr {
     border-left-color: #d9534f;
 }
 
-.form-control {
-    width: initial;
-}
-
 .input-group > .form-control {
     flex: initial;
     width: initial;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -123,10 +123,6 @@ hr {
     border-left-color: #d9534f;
 }
 
-.form-control {
-    width: initial;
-}
-
 .input-group > .form-control {
     flex: initial;
     width: initial;

--- a/templates/resister.html
+++ b/templates/resister.html
@@ -1,33 +1,14 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" media="screen and (max-width:768px)" href="{{ url_for('static', filename = 'css/sp-style.css') }}">
-    <link rel="stylesheet" media="screen and (min-width:769px)" href="{{ url_for('static', filename = 'css/style.css') }}">
-    <title>SDVX-EXスコアツール</title>
-</head>
-<body>
-    <header class="site-header wrapper">
-        <div class="header">
-            <a href="/" class="appname">SDVX-EXスコアツール</a>
+{%- extends "layout.html" %}
+{%- block content %}
+    <div class="resister-form container">
+        <div class="bd-callout bd-callout-info">
+            スコアデータ(CSV)を貼りつけて、送信ボタンを押してください。
         </div>
-    </header>
-    <div class="resister-form">
-        <p>スコアデータ(CSV)を貼ってください。</p>
-        <form action="/resister/hiscore" method="POST">
-            <textarea name="score" cols="100" rows="30"></textarea><br/>
-            <input type="submit" value="送信">
-        </form>
+        <div class="mb-3">
+            <form action="/resister/hiscore" method="POST">
+                <textarea class="form-control" name="score" rows="10"></textarea><br/>
+                <button class="btn btn-primary" type="submit">送信</button>
+            </form>
+        </div>
     </div>
-    <hr>
-
-    <hr>
-    <footer class="site-footer wrapper">
-        <div class="footer">
-        </div>
-    </footer>
-</body>
-</html>
+{%- endblock %}


### PR DESCRIPTION
close #7

## スクリーンショット
### PC
<img width="1439" alt="スクリーンショット 2021-12-27 8 48 32" src="https://user-images.githubusercontent.com/40511624/147422855-7556d726-9e38-43c2-9d4e-f64d3488cd79.png">

### モバイル
<img width="378" alt="スクリーンショット 2021-12-27 8 51 06" src="https://user-images.githubusercontent.com/40511624/147422857-8e631908-0135-4c58-8421-30172a6b864f.png">

## やったこと
- レイアウト変更
- 文面修正

## 確認してほしいこと
- [x] reiyiyi さんのローカル環境で適切に表示されるか確認をお願いします。
- [x] その他、レイアウトやコードに違和感や問題がないか確認をお願いします。