### PR TITLE
strengths.htmlのレイアウト修正

### DIFF
--- a/static/css/sp-style.css
+++ b/static/css/sp-style.css
@@ -63,13 +63,7 @@ hr {
 }
 
 .to-ranking-button {
-    color: blue;
-    background: white;
     font-weight: bolder;
-    padding: 0.5em 0;
-    width: 100%;
-    display: inline-block;
-    text-align: left;
     text-decoration: none;
 }
 

--- a/static/css/sp-style.css
+++ b/static/css/sp-style.css
@@ -128,3 +128,8 @@ hr {
 .title {
     margin: 1rem;
 }
+
+.sp-table-layout {
+    table-layout: fixed;
+    width: 300%;
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -63,13 +63,7 @@ hr {
 }
 
 .to-ranking-button {
-    color: blue;
-    background: white;
     font-weight: bolder;
-    padding: 0.5em 0;
-    width: 100%;
-    display: inline-block;
-    text-align: left;
     text-decoration: none;
 }
 

--- a/templates/strengths.html
+++ b/templates/strengths.html
@@ -3,27 +3,27 @@
     <div class="strengths-list container">
         <h1 class="title">武器曲リスト</h1>
         <div class="table-responsive">
-            <table class="table table-striped">
+            <table class="table table-striped sp-table-layout">
                 <thead>
                     <tr>
-                        <th scope="col">順位</th>
-                        <th scope="col">楽曲名</th>
-                        <th scope="col">難易度</th>
-                        <th scope="col">レベル</th>
-                        <th scope="col">EXスコア</th>
-                        <th scope="col">MAX-</th>
-                        <th scope="col">上位</th>
+                        <th class="col-1">順位</th>
+                        <th class="col-6">楽曲名</th>
+                        <th class="col-1">難易度</th>
+                        <th class="col-1">レベル</th>
+                        <th class="col-1">EXスコア</th>
+                        <th class="col-1">MAX-</th>
+                        <th class="col-1">上位</th>
                     </tr>
                 </thead>
                 <tbody>
                     {% for i in range(data_num) %}
                         <tr>
                             <td scope="row">{{ i+1 }}</td>
-                            <td style="white-space: nowrap;"><a href="/ranking/{{ strengths_list[i]['ID'] }}" class="to-ranking-button">{{ strengths_list[i]["楽曲名"] }}</a></td>
+                            <td><a href="/ranking/{{ strengths_list[i]['ID'] }}" class="to-ranking-button">{{ strengths_list[i]["楽曲名"] }}</a></td>
                             <td>{{ strengths_list[i]["難易度"] }}</td>
                             <td>{{ strengths_list[i]["レベル"] }}</td>
                             <td>{{ strengths_list[i]["EXスコア"] }}</td>
-                            <td>{{ strengths_list[i]["MAX-"] }}</td>
+                            <td>MAX-{{ strengths_list[i]["MAX-"] }}</td>
                             <td>{{ strengths_list[i]["上位%"] }}%</td>
                         </tr>
                     {% endfor %}

--- a/templates/strengths.html
+++ b/templates/strengths.html
@@ -1,52 +1,34 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" media="screen and (max-width:768px)" href="{{ url_for('static', filename = 'css/sp-style.css') }}">
-    <link rel="stylesheet" media="screen and (min-width:769px)" href="{{ url_for('static', filename = 'css/style.css') }}">
-    <title>SDVX-EXスコアツール</title>
-</head>
-<body>
-    <header class="site-header wrapper">
-        <div class="header">
-            <a href="/" class="appname">SDVX-EXスコアツール</a>
+{%- extends "layout.html" %}
+{%- block content %}
+    <div class="strengths-list container">
+        <h1 class="title">武器曲リスト</h1>
+        <div class="table-responsive">
+            <table class="table table-striped">
+                <thead>
+                    <tr>
+                        <th scope="col">順位</th>
+                        <th scope="col">楽曲名</th>
+                        <th scope="col">難易度</th>
+                        <th scope="col">レベル</th>
+                        <th scope="col">EXスコア</th>
+                        <th scope="col">MAX-</th>
+                        <th scope="col">上位</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for i in range(data_num) %}
+                        <tr>
+                            <td scope="row">{{ i+1 }}</td>
+                            <td style="white-space: nowrap;"><a href="/ranking/{{ strengths_list[i]['ID'] }}" class="to-ranking-button">{{ strengths_list[i]["楽曲名"] }}</a></td>
+                            <td>{{ strengths_list[i]["難易度"] }}</td>
+                            <td>{{ strengths_list[i]["レベル"] }}</td>
+                            <td>{{ strengths_list[i]["EXスコア"] }}</td>
+                            <td>{{ strengths_list[i]["MAX-"] }}</td>
+                            <td>{{ strengths_list[i]["上位%"] }}%</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
         </div>
-    </header>
-    <div class="strengths-list">
-        <p>武器曲リスト</p>
-        <p>(楽曲名をクリックすることで、その楽曲の難易度の譜面のランキングページにアクセスすることができるようになりました)</p>
-        <table border="1">
-            <tr>
-                <th>順位</th>
-                <th>楽曲名</th>
-                <th>難易度</th>
-                <th>レベル</th>
-                <th>EXスコア</th>
-                <th>MAX-</th>
-                <th>上位</th>
-            </tr>
-            {% for i in range(data_num) %}
-            <tr>
-                <td style="text-align: right;">{{ i+1 }}</td>
-                <td><a href="/ranking/{{ strengths_list[i]['ID'] }}" class="to-ranking-button">{{ strengths_list[i]["楽曲名"] }}</a></td>
-                <td>{{ strengths_list[i]["難易度"] }}</td>
-                <td style="text-align: right;">{{ strengths_list[i]["レベル"] }}</td>
-                <td style="text-align: right;">{{ strengths_list[i]["EXスコア"] }}</td>
-                <td>MAX-{{ strengths_list[i]["MAX-"] }}</td>
-                <td style="text-align: right;">{{ strengths_list[i]["上位%"] }}%</td>
-            </tr>
-            {% endfor %}
-        </table>
     </div>
-    <hr>
-
-    <hr>
-    <footer class="site-footer wrapper">
-        <div class="footer">
-        </div>
-    </footer>
-</body>
-</html>
+{%- endblock %}


### PR DESCRIPTION
close #16 

## スクリーンショット
### PC
<img width="1440" alt="スクリーンショット 2021-12-28 22 51 09" src="https://user-images.githubusercontent.com/40511624/147573673-6f931562-e9ff-40fc-a906-547efaf3d178.png">

### モバイル
![ダウンロード](https://user-images.githubusercontent.com/40511624/147574040-d1ad88a9-f397-447a-965a-7a899196ab52.gif)

## やったこと
- レイアウト変更
- モバイル表示の際、表を横スクロールできるようにした
- 文面削除
  - 冒頭の説明文
  -  「MAX-」の部分   

## 確認してほしいこと
- [x] reiyiyi さんのローカル環境で適切に表示されるか確認をお願いします。
- [x] その他、レイアウトやコードに違和感や問題がないか確認をお願いします。