### PR TITLE
notice.htmlのレイアウト修正

### DIFF
--- a/templates/notice.html
+++ b/templates/notice.html
@@ -1,66 +1,35 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" media="screen and (max-width:768px)" href="{{ url_for('static', filename = 'css/sp-style.css') }}">
-    <link rel="stylesheet" media="screen and (min-width:769px)" href="{{ url_for('static', filename = 'css/style.css') }}">
-    <title>SDVX-EXスコアツール</title>
-</head>
-<body>
-    <header class="site-header wrapper">
-        <div class="header">
-            <a href="/" class="appname">SDVX-EXスコアツール</a>
-        </div>
-    </header>
-    <div class="notice">
-        <p>通知</p>
+{%- extends "layout.html" %}
+{%- block content %}
+    <div id="notice" class="container">
+        <h1 class="title">通知</h1>
         {% for i in range(data_num) %}
-        <hr>
-        {% if notice_list[-i-1]["スコア"] != notice_list[-i-1]["好敵手更新後スコア"] %}
+        <div class="card">
+            <div class="card-body">
+            {% if notice_list[-i-1]["スコア"] != notice_list[-i-1]["好敵手更新後スコア"] %}
 
-        {% if "MAX" in notice_list[-i-1] %}
-        <p>{{notice_list[-i-1]["好敵手名"]}}さんが
-            {{notice_list[-i-1]["楽曲名"]}}[{{notice_list[-i-1]["難易度"]}} {{notice_list[-i-1]["レベル"]}}]
-            において、あなたのEXスコア {{notice_list[-i-1]["スコア"]}}(MAX-{{notice_list[-i-1]["MAX"] - notice_list[-i-1]["スコア"]}}) を抜かしました。</p>
-        <p>{{notice_list[-i-1]["好敵手名"]}}さんのスコア:
-            {{ notice_list[-i-1]["好敵手更新前スコア"] }}(MAX-{{ notice_list[-i-1]["MAX"] - notice_list[-i-1]["好敵手更新前スコア"] }})&nbsp;&nbsp;&nbsp;---[+{{ notice_list[-i-1]["好敵手更新後スコア"] - notice_list[-i-1]["好敵手更新前スコア"] }}]→&nbsp;&nbsp;&nbsp;{{ notice_list[-i-1]["好敵手更新後スコア"] }}(MAX-{{ notice_list[-i-1]["MAX"] - notice_list[-i-1]["好敵手更新後スコア"] }})</p>
-        {% else %}
-        <p>{{notice_list[-i-1]["好敵手名"]}}さんが
-            {{notice_list[-i-1]["楽曲名"]}}[{{notice_list[-i-1]["難易度"]}} {{notice_list[-i-1]["レベル"]}}]
-            において、あなたのEXスコア {{notice_list[-i-1]["スコア"]}} を抜かしました。</p>
-        <p>{{notice_list[-i-1]["好敵手名"]}}さんのスコア:
-            {{ notice_list[-i-1]["好敵手更新前スコア"] }}&nbsp;&nbsp;&nbsp;---[+{{ notice_list[-i-1]["好敵手更新後スコア"] - notice_list[-i-1]["好敵手更新前スコア"] }}]→&nbsp;&nbsp;&nbsp;{{ notice_list[-i-1]["好敵手更新後スコア"] }}</p>
-        {% endif %}
+            {% if "MAX" in notice_list[-i-1] %}
+                <p>{{notice_list[-i-1]["楽曲名"]}}[{{notice_list[-i-1]["難易度"]}} {{notice_list[-i-1]["レベル"]}}]のEXスコア({{notice_list[-i-1]["スコア"]}}(MAX-{{notice_list[-i-1]["MAX"] - notice_list[-i-1]["スコア"]}}))が 
+                    {{notice_list[-i-1]["好敵手名"]}} さんに抜かされました。</p>
+                {{notice_list[-i-1]["好敵手名"]}}さんのスコア: {{ notice_list[-i-1]["好敵手更新前スコア"] }}(MAX-{{ notice_list[-i-1]["MAX"] - notice_list[-i-1]["好敵手更新前スコア"] }}) → <b>{{ notice_list[-i-1]["好敵手更新後スコア"] }}(MAX-{{ notice_list[-i-1]["MAX"] - notice_list[-i-1]["好敵手更新後スコア"] }})[+{{ notice_list[-i-1]["好敵手更新後スコア"] - notice_list[-i-1]["好敵手更新前スコア"] }}]</b>
+            {% else %}
+                <p>{{notice_list[-i-1]["楽曲名"]}}[{{notice_list[-i-1]["難易度"]}} {{notice_list[-i-1]["レベル"]}}]のEXスコア({{notice_list[-i-1]["スコア"]}})が 
+                    {{notice_list[-i-1]["好敵手名"]}} さんに抜かされました。</p>
+                {{notice_list[-i-1]["好敵手名"]}}さんのスコア: {{ notice_list[-i-1]["好敵手更新前スコア"] }} → <b>{{ notice_list[-i-1]["好敵手更新後スコア"] }}[+{{ notice_list[-i-1]["好敵手更新後スコア"] - notice_list[-i-1]["好敵手更新前スコア"] }}]</b>
+            {% endif %}
 
-        {% else %}
+            {% else %}
 
-        {% if "MAX" in notice_list[-i-1] %}
-        <p>{{notice_list[-i-1]["好敵手名"]}}さんが
-            {{notice_list[-i-1]["楽曲名"]}}[{{notice_list[-i-1]["難易度"]}} {{notice_list[-i-1]["レベル"]}}]
-            において、あなたのEXスコア {{notice_list[-i-1]["スコア"]}}(MAX-{{notice_list[-i-1]["MAX"] - notice_list[-i-1]["スコア"]}}) と並びました。</p>
-        <p>{{notice_list[-i-1]["好敵手名"]}}さんのスコア:
-            {{ notice_list[-i-1]["好敵手更新前スコア"] }}(MAX-{{ notice_list[-i-1]["MAX"] - notice_list[-i-1]["好敵手更新前スコア"] }})&nbsp;&nbsp;&nbsp;---[+{{ notice_list[-i-1]["好敵手更新後スコア"] - notice_list[-i-1]["好敵手更新前スコア"] }}]→&nbsp;&nbsp;&nbsp;{{ notice_list[-i-1]["好敵手更新後スコア"] }}(MAX-{{ notice_list[-i-1]["MAX"] - notice_list[-i-1]["好敵手更新後スコア"] }})</p>
-        {% else %}
-        <p>{{notice_list[-i-1]["好敵手名"]}}さんが
-            {{notice_list[-i-1]["楽曲名"]}}[{{notice_list[-i-1]["難易度"]}} {{notice_list[-i-1]["レベル"]}}]
-            において、あなたのEXスコア {{notice_list[-i-1]["スコア"]}} と並びました。</p>
-        <p>{{notice_list[-i-1]["好敵手名"]}}さんのスコア:
-            {{ notice_list[-i-1]["好敵手更新前スコア"] }}&nbsp;&nbsp;&nbsp;---[+{{ notice_list[-i-1]["好敵手更新後スコア"] - notice_list[-i-1]["好敵手更新前スコア"] }}]→&nbsp;&nbsp;&nbsp;{{ notice_list[-i-1]["好敵手更新後スコア"] }}</p>
-        {% endif %}
+            {% if "MAX" in notice_list[-i-1] %}
+                <p>{{notice_list[-i-1]["楽曲名"]}}[{{notice_list[-i-1]["難易度"]}} {{notice_list[-i-1]["レベル"]}}]のEXスコアが {{notice_list[-i-1]["好敵手名"]}} さんに並ばれました。</p>
+                {{notice_list[-i-1]["好敵手名"]}}さんのスコア: {{ notice_list[-i-1]["好敵手更新前スコア"] }}(MAX-{{ notice_list[-i-1]["MAX"] - notice_list[-i-1]["好敵手更新前スコア"] }}) → <b>{{ notice_list[-i-1]["好敵手更新後スコア"] }}(MAX-{{ notice_list[-i-1]["MAX"] - notice_list[-i-1]["好敵手更新後スコア"] }})[+{{ notice_list[-i-1]["好敵手更新後スコア"] - notice_list[-i-1]["好敵手更新前スコア"] }}]</b>
+            {% else %}
+                <p>{{notice_list[-i-1]["楽曲名"]}}[{{notice_list[-i-1]["難易度"]}} {{notice_list[-i-1]["レベル"]}}]のEXスコアが {{notice_list[-i-1]["好敵手名"]}} さんに並ばれました。</p>
+                {{notice_list[-i-1]["好敵手名"]}}さんのスコア: {{ notice_list[-i-1]["好敵手更新前スコア"] }} → <b>{{ notice_list[-i-1]["好敵手更新後スコア"] }}[+{{ notice_list[-i-1]["好敵手更新後スコア"] - notice_list[-i-1]["好敵手更新前スコア"] }}]</b>
+            {% endif %}
 
-        {% endif %}
-
+            {% endif %}
+            </div>
+        </div>
         {% endfor %}
     </div>
-    <hr>
-
-    <hr>
-    <footer class="site-footer wrapper">
-        <div class="footer">
-        </div>
-    </footer>
-</body>
-</html>
+{%- endblock %}


### PR DESCRIPTION
close #11 

## スクリーンショット
### PC
<img width="1439" alt="スクリーンショット 2021-12-30 14 53 43" src="https://user-images.githubusercontent.com/40511624/147726424-cb2ad048-d204-41ce-b9d9-cab1ecad1265.png">

### モバイル
<img width="374" alt="スクリーンショット 2021-12-30 14 54 16" src="https://user-images.githubusercontent.com/40511624/147726428-3f21c95e-8ce1-41e2-89b8-4c2cdb023278.png">

## やったこと
- レイアウト変更
- 文面修正

## 確認してほしいこと
- [x] reiyiyi さんのローカル環境で適切に表示されるか確認をお願いします。
- [x] その他、レイアウトやコードに違和感や問題がないか確認をお願いします。