### PR TITLE
index.htmlのレイアウト修正

### DIFF
--- a/static/css/sp-style.css
+++ b/static/css/sp-style.css
@@ -125,7 +125,17 @@ hr {
     margin: 1rem;
 }
 
+.sp-register-rival-hr {
+    margin: 1rem 0;
+    border-bottom: 1px solid black;
+}
+
 .sp-table-layout {
     table-layout: fixed;
     width: 300%;
+}
+
+#menu > a {
+    width: 100%;
+    margin: 4px;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -125,3 +125,13 @@ hr {
 .title {
     margin: 1rem;
 }
+
+.table-spuc {
+    width: 75%;
+    margin: auto;
+} 
+
+#menu > a {
+    width: 30%;
+    margin: 4px;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,58 +1,51 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" media="screen and (max-width:768px)" href="{{ url_for('static', filename = 'css/sp-style.css') }}">
-    <link rel="stylesheet" media="screen and (min-width:769px)" href="{{ url_for('static', filename = 'css/style.css') }}">
-    <title>SDVX-EXスコアツール</title>
-</head>
-<body>
-    <header class="site-header wrapper">
-        <div class="header">
-            <a href="/" class="appname">SDVX-EXスコアツール</a>
+{%- extends "layout.html" %}
+{%- block content %}
+    <div id="index" class="container">
+        <div class="row">
+            <div class="col-lg-6">
+                <h2 class="title">{{user_name}}さんのマイページ</h1>
+                <div id="user_info" class="card">
+                    <div class="card-body">
+                        ユーザーID: {{user}}
+                    </div>
+                </div>
+                <div id="menu" class="inline accordion" style="margin: 1rem;">
+                    <a href="{{url_for('resister')}}" class="btn btn-primary">スコア登録</a>
+                    <a href="{{url_for('recently_hiscore')}}" class="btn btn-primary">更新スコア確認</a>
+                    <a href="{{url_for('myscore')}}" class="btn btn-primary">スコア確認</a>
+                    <a href="{{url_for('strengths')}}" class="btn btn-primary">武器曲</a>
+                    <a href="{{url_for('rival')}}" class="btn btn-primary">好敵手</a>
+                    <a href="{{url_for('notice')}}" class="btn btn-primary">通知</a>
+                    <a href="{{url_for('settings')}}" class="btn btn-primary">設定</a>
+                    <a href="{{url_for('logout')}}" class="btn btn-primary">ログアウト</a>
+                    <a href="{{url_for('manual')}}" class="btn btn-primary">使い方</a>
+                </div>
+                <div class="sp-register-rival-hr"></div>
+            </div>
+            <div class="col-lg-6">
+                <div id="s-puc" class="inline">
+                    <h2 class="title">S-PUC数</h3>
+                    <table class="table table-striped table-sm table-bordered table-spuc">
+                        <caption>※EXH譜面以上</caption>
+                        <thead>
+                            <tr>
+                                <th>レベル</th>
+                                <th>S-PUC数</th>
+                                <th>譜面数</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for i in range(spuc_data|length) %}
+                            <tr>
+                                <td style="text-align: right;" scope="row">{{ i+7 }}</td>
+                                <td style="text-align: right;">{{ spuc_data[i] }}</td>
+                                <td style="text-align: right;">{{ num_data[i] }}</td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
         </div>
-    </header>
-    <p>こんにちは、{{user_name}}さん</p>
-    <hr>
-    <p>ユーザーID: {{ user }}</p>
-    <p>ユーザー名: {{ user_name }}</p>
-    <hr>
-    <div class="inline">
-        <a href="{{url_for('resister')}}" class="button">スコア登録</a>
-        <a href="{{url_for('recently_hiscore')}}" class="button">更新スコア確認</a>
-        <a href="{{url_for('myscore')}}" class="button">スコア確認</a>
-        <a href="{{url_for('strengths')}}" class="button">武器曲</a>
-        <a href="{{url_for('rival')}}" class="button">好敵手</a>
-        <a href="{{url_for('notice')}}" class="button">通知</a>
-        <a href="{{url_for('settings')}}" class="button">設定</a>
-        <a href="{{url_for('logout')}}" class="button">ログアウト</a>
-        <a href="{{url_for('manual')}}" class="button">使い方</a>
     </div>
-    <hr>
-    <div class="spuc-list">
-        EXH譜面以上におけるS-PUC数
-        <table border="1">
-            <tr>
-                <th>レベル</th>
-                <th>S-PUC数</th>
-                <th>譜面数</th>
-            </tr>
-            {% for i in range(spuc_data|length) %}
-            <tr>
-                <td style="text-align: right;">{{ i+7 }}</td>
-                <td style="text-align: right;">{{ spuc_data[i] }}</td>
-                <td style="text-align: right;">{{ num_data[i] }}</td>
-            </tr>
-            {% endfor %}
-        </table>
-    </div>
-    <hr>
-    <footer class="site-footer wrapper">
-        <div class="footer">
-        </div>
-    </footer>
-</body>
-</html>
+{%- endblock %}


### PR DESCRIPTION
close #4

## スクリーンショット
### PC
<img width="1440" alt="スクリーンショット 2022-01-04 11 07 34" src="https://user-images.githubusercontent.com/40511624/148000393-24057b5e-96e8-429c-a293-6acc60cffc7f.png">

### モバイル
<img width="500" alt="スクリーンショット" src="https://user-images.githubusercontent.com/40511624/148000400-bc4ef521-c63c-4889-8405-96d1fe4873be.png">


## やったこと
- レイアウト変更
- 文面修正
- ユーザー名が重複している部分を削除

## 確認してほしいこと
- [ ] reiyiyi さんのローカル環境で適切に表示されるか確認をお願いします。
- [ ] その他、レイアウトやコードに違和感や問題がないか確認をお願いします。