### PR TITLE
ranking.htmlのレイアウト修正

### DIFF
--- a/static/css/sp-style.css
+++ b/static/css/sp-style.css
@@ -52,17 +52,6 @@ hr {
 }
 
 .ranking-button {
-    color: blue;
-    background: white;
-    font-weight: bolder;
-    padding: 0.5em 0;
-    width: 100%;
-    display: inline-block;
-    text-align: center;
-    text-decoration: none;
-}
-
-.to-ranking-button {
     font-weight: bolder;
     text-decoration: none;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -52,17 +52,6 @@ hr {
 }
 
 .ranking-button {
-    color: blue;
-    background: white;
-    font-weight: bolder;
-    padding: 0.5em 0;
-    width: 100%;
-    display: inline-block;
-    text-align: center;
-    text-decoration: none;
-}
-
-.to-ranking-button {
     font-weight: bolder;
     text-decoration: none;
 }
@@ -124,4 +113,9 @@ hr {
 
 .title {
     margin: 1rem;
+}
+
+.ranking-table {
+    width: 75%;
+    margin: auto;
 }

--- a/templates/ranking.html
+++ b/templates/ranking.html
@@ -1,49 +1,32 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" media="screen and (max-width:768px)" href="{{ url_for('static', filename = 'css/sp-style.css') }}">
-    <link rel="stylesheet" media="screen and (min-width:769px)" href="{{ url_for('static', filename = 'css/style.css') }}">
-    <title>SDVX-EXスコアツール</title>
-</head>
-<body>
-    <header class="site-header wrapper">
-        <div class="header">
-            <a href="/" class="appname">SDVX-EXスコアツール</a>
-        </div>
-    </header>
-    <div class="ranking-list">
-        {{ effect_data["楽曲名"] }}[{{ effect_data["難易度"] }} {{ effect_data["レベル"] }}]のランキング
-        <table border="1">
-            <tr>
-                <th>順位</th>
-                <th>ユーザー名</th>
-                <th>EXスコア</th>
-                <th>MAX-</th>
-            </tr>
-            {% for i in range(100) %}
-            <tr>
-                <td style="text-align: right;">{{ i+1 }}位</td>
-                {% if ranking_list[i]["ユーザーID"] != "[SECRET]" and ranking_list[i]["ユーザーID"] != "---" %}
-                <td><a href='/user/{{ranking_list[i]["ユーザーID"]}}' class="ranking-button">{{ ranking_list[i]["ユーザー名"] }}</a></td>
+{%- extends "layout.html" %}
+{%- block content %}
+    <div id="ranking-list" class="container">
+        <h1 class="title" style="text-align: center;">{{ effect_data["楽曲名"] }}[{{ effect_data["難易度"] }} {{ effect_data["レベル"] }}]</h1>
+        <div class="ranking-table">
+            <table class="table table-striped">
+                <tr>
+                    <th>順位</th>
+                    <th>ユーザー名</th>
+                    <th>EXスコア</th>
+                    <th>MAX-</th>
+                </tr>
+                {% for i in range(ranking_list|length) %}
+                {% if current_user_id == ranking_list[i]["ユーザーID"] %}
+                <tr style="background-color: lightsalmon;">
                 {% else %}
-                <td style="text-align: center;">{{ ranking_list[i]["ユーザー名"] }}</td>
+                <tr>
                 {% endif %}
-                <td style="text-align: right;">{{ ranking_list[i]["EXスコア"] }}</td>
-                <td>MAX-{{ ranking_list[i]["MAX-"] }}</td>
-            </tr>
-            {% endfor %}
-        </table>
-    </div>
-    <hr>
-
-    <hr>
-    <footer class="site-footer wrapper">
-        <div class="footer">
+                    <td>{{ i+1 }}位</td>
+                    {% if ranking_list[i]["ユーザーID"] != "[SECRET]" and ranking_list[i]["ユーザーID"] != "---" %}
+                    <td><a class="ranking-button" href='/user/{{ranking_list[i]["ユーザーID"]}}'>{{ ranking_list[i]["ユーザー名"] }}</a></td>
+                    {% else %}
+                    <td>{{ ranking_list[i]["ユーザー名"] }}</td>
+                    {% endif %}
+                    <td>{{ ranking_list[i]["EXスコア"] }}</td>
+                    <td>MAX-{{ ranking_list[i]["MAX-"] }}</td>
+                </tr>
+                {% endfor %}
+            </table>
         </div>
-    </footer>
-</body>
-</html>
+    </div>
+{%- endblock %}

--- a/templates/strengths.html
+++ b/templates/strengths.html
@@ -19,7 +19,7 @@
                     {% for i in range(data_num) %}
                         <tr>
                             <td scope="row">{{ i+1 }}</td>
-                            <td><a href="/ranking/{{ strengths_list[i]['ID'] }}" class="to-ranking-button">{{ strengths_list[i]["楽曲名"] }}</a></td>
+                            <td><a href="/ranking/{{ strengths_list[i]['ID'] }}" class="ranking-button">{{ strengths_list[i]["楽曲名"] }}</a></td>
                             <td>{{ strengths_list[i]["難易度"] }}</td>
                             <td>{{ strengths_list[i]["レベル"] }}</td>
                             <td>{{ strengths_list[i]["EXスコア"] }}</td>


### PR DESCRIPTION
close #10 

## スクリーンショット
### PC
<img width="1440" alt="スクリーンショット 2022-01-04 11 58 41" src="https://user-images.githubusercontent.com/40511624/148003983-6c1bd0bf-ee8c-4503-a059-b9d52594c4b4.png">

### モバイル
<img width="377" alt="スクリーンショット 2022-01-04 11 58 30" src="https://user-images.githubusercontent.com/40511624/148003978-8edf9613-b76e-44d8-a592-c60de03790f5.png">

## やったこと
- レイアウト変更
- 文面修正
- 自身がランクインしていた場合、色をつけてわかりやすくした

## 確認してほしいこと
- [ ] reiyiyi さんのローカル環境で適切に表示されるか確認をお願いします。
- [ ] 自身がランクインしていた場合、色が正しく付くかどうか確認をお願いします。
- [ ] 背景の色が違和感がないかどうか確認をお願いします。
- [ ] その他、レイアウトやコードに違和感や問題がないか確認をお願いします。