### PR TITLE
score周りのレイアウト修正

### DIFF
--- a/static/css/sp-style.css
+++ b/static/css/sp-style.css
@@ -52,31 +52,15 @@ hr {
 }
 
 .ranking-button {
-    color: blue;
-    background: white;
-    font-weight: bolder;
-    padding: 0.5em 0;
-    width: 100%;
-    display: inline-block;
-    text-align: center;
-    text-decoration: none;
-}
-
-.to-ranking-button {
     font-weight: bolder;
     text-decoration: none;
 }
 
 .level-button {
-    color: white;
-    background: #000000;
-    font-weight: bolder;
-    padding: 0.5em 0;
-    width: 18%;
+    width: 16%;
     margin: 2px 0;
     display: inline-block;
     text-align: center;
-    text-decoration: none;
 }
 
 .inline {
@@ -128,4 +112,13 @@ hr {
 .sp-table-layout {
     table-layout: fixed;
     width: 300%;
+}
+
+.score-table {
+    table-layout: fixed;
+    width: 200%;
+}
+
+.sp-score-music-name {
+    width: 40% !important;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -52,31 +52,15 @@ hr {
 }
 
 .ranking-button {
-    color: blue;
-    background: white;
-    font-weight: bolder;
-    padding: 0.5em 0;
-    width: 100%;
-    display: inline-block;
-    text-align: center;
-    text-decoration: none;
-}
-
-.to-ranking-button {
     font-weight: bolder;
     text-decoration: none;
 }
 
 .level-button {
-    color: white;
-    background: #000000;
-    font-weight: bolder;
-    padding: 0.5em 0;
     width: 9%;
     margin: 2px 0;
     display: inline-block;
     text-align: center;
-    text-decoration: none;
 }
 
 .inline {
@@ -124,4 +108,9 @@ hr {
 
 .title {
     margin: 1rem;
+}
+
+.score-table {
+    width: 90%;
+    margin: auto;
 }

--- a/templates/hiscore.html
+++ b/templates/hiscore.html
@@ -1,51 +1,34 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" media="screen and (max-width:768px)" href="{{ url_for('static', filename = 'css/sp-style.css') }}">
-    <link rel="stylesheet" media="screen and (min-width:769px)" href="{{ url_for('static', filename = 'css/style.css') }}">
-    <title>SDVX-EXスコアツール</title>
-</head>
-<body>
-    <header class="site-header wrapper">
-        <div class="header">
-            <a href="/" class="appname">SDVX-EXスコアツール</a>
-        </div>
-    </header>
-    <div class="hiscore">
+{%- extends "layout.html" %}
+{%- block content %}
+    <div id="hiscore" class="container">
+        <h1 class="title">{{mode}}のEXスコア更新</h1>
         {% if resister_error_list|length > 0 %}
-        <p>
-            !! 一部の譜面において、スコアデータを登録することができませんでした。
-            登録することができなかった譜面の情報(最大100件)を下に記載させていただきます。
-            この譜面の情報につきましてはログとして記録しており、こちらのデータに不備が見つかった場合は直ちに修正いたします。
+        <div class="bd-callout bd-callout-danger">
+            <p>一部の譜面において、スコアデータを登録することができませんでした。</p>
+            <p>登録することができなかった譜面の情報(最大100件)を下に記載させていただきます。</p>
+            <p>この譜面の情報につきましてはログとして記録しており、こちらのデータに不備が見つかった場合は直ちに修正いたします。</p>
             なお、「今回のEXスコア更新」はいつも通り下に記載しております。
-        </p>
-        <hr>
-        {% for error_data in resister_error_list %}
-        <p>{{ error_data["楽曲名"] }}[{{ error_data["難易度"] }}]</p>
-        {% endfor %}
+        </div>
+        <div class="card">
+            <div class="card-body">
+                {% for error_data in resister_error_list %}
+                <li>{{ error_data["楽曲名"] }}[{{ error_data["難易度"] }}]</li>
+                {% endfor %}
+            </div>
+        </div>
         <hr>
         {% endif %}
-        <h3>{{mode}}のEXスコア更新</h3>
         {% for i in range(data_num) %}
-        <hr>
-        <p>{{ hi_score_list[-i-1]["楽曲名"] }}[{{ hi_score_list[-i-1]["難易度"] }} {{ hi_score_list[-i-1]["レベル"] }}]</p>
-        {% if "MAX" in hi_score_list[-i-1] %}
-        <p>{{ hi_score_list[-i-1]["更新前スコア"] }}(MAX-{{ hi_score_list[-i-1]["MAX"] - hi_score_list[-i-1]["更新前スコア"] }})&nbsp;&nbsp;&nbsp;---[+{{ hi_score_list[-i-1]["更新後スコア"] - hi_score_list[-i-1]["更新前スコア"] }}]→&nbsp;&nbsp;&nbsp;{{ hi_score_list[-i-1]["更新後スコア"] }}(MAX-{{ hi_score_list[-i-1]["MAX"] - hi_score_list[-i-1]["更新後スコア"] }})</p>
-        {% else %}
-        <p>{{ hi_score_list[-i-1]["更新前スコア"] }}&nbsp;&nbsp;&nbsp;---[+{{ hi_score_list[-i-1]["更新後スコア"] - hi_score_list[-i-1]["更新前スコア"] }}]→&nbsp;&nbsp;&nbsp;{{ hi_score_list[-i-1]["更新後スコア"] }}</p>
+        <div class="card">
+            <div class="card-body">
+                <p>{{ hi_score_list[-i-1]["楽曲名"] }}[{{ hi_score_list[-i-1]["難易度"] }} {{ hi_score_list[-i-1]["レベル"] }}]</p>
+                {% if "MAX" in hi_score_list[-i-1] %}
+                {{ hi_score_list[-i-1]["更新前スコア"] }}(MAX-{{ hi_score_list[-i-1]["MAX"] - hi_score_list[-i-1]["更新前スコア"] }}) → <b>{{ hi_score_list[-i-1]["更新後スコア"] }}(MAX-{{ hi_score_list[-i-1]["MAX"] - hi_score_list[-i-1]["更新後スコア"] }})[+{{ hi_score_list[-i-1]["更新後スコア"] - hi_score_list[-i-1]["更新前スコア"] }}]</b>
+                {% else %}
+                {{ hi_score_list[-i-1]["更新前スコア"] }} → <b>{{ hi_score_list[-i-1]["更新後スコア"] }}[+{{ hi_score_list[-i-1]["更新後スコア"] - hi_score_list[-i-1]["更新前スコア"] }}]</b>
+            </div>
+        </div>
         {% endif %}
         {% endfor %}
     </div>
-    <hr>
-
-    <hr>
-    <footer class="site-footer wrapper">
-        <div class="footer">
-        </div>
-    </footer>
-</body>
-</html>
+{%- endblock %}

--- a/templates/level_myscore.html
+++ b/templates/level_myscore.html
@@ -1,47 +1,28 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" media="screen and (max-width:768px)" href="{{ url_for('static', filename = 'css/sp-style.css') }}">
-    <link rel="stylesheet" media="screen and (min-width:769px)" href="{{ url_for('static', filename = 'css/style.css') }}">
-    <title>SDVX-EXスコアツール</title>
-</head>
-<body>
-    <header class="site-header wrapper">
-        <div class="header">
-            <a href="/" class="appname">SDVX-EXスコアツール</a>
+{%- extends "layout.html" %}
+{%- block content %}
+    <div id="myscore-list" class="container">
+        <h1 class="title">LEVEL {{ level }}</h1>
+        <div class="table-responsive">
+            <table class="table table-striped score-table">
+                <thead class="table-light">
+                    <tr>
+                        <th class="col-9 sp-score-music-name">楽曲名</th>
+                        <th class="col-1">難易度</th>
+                        <th class="col-1">EXスコア</th>
+                        <th class="col-1">MAX-</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for data in my_score_list %}
+                    <tr>
+                        <td><a class="ranking-button" href="/ranking/{{ data['effect_id'] }}">{{ data["楽曲名"] }}</a></td>
+                        <td>{{ data["難易度"] }}</td>
+                        <td>{{ data["EXスコア"] }}</td>
+                        <td>MAX-{{ data["MAX-"] }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
         </div>
-    </header>
-    <div class="myscore-list">
-        {{ level }}のスコア
-        <table border="1">
-            <tr>
-                <th>楽曲名</th>
-                <th>難易度</th>
-                <th>EXスコア</th>
-                <th>MAX-</th>
-                <th>ランキング</th>
-            </tr>
-            {% for data in my_score_list %}
-            <tr>
-                <td>{{ data["楽曲名"] }}</td>
-                <td>{{ data["難易度"] }}</td>
-                <td style="text-align: right;">{{ data["EXスコア"] }}</td>
-                <td>MAX-{{ data["MAX-"] }}</td>
-                <td style="text-align: right;"><a href="/ranking/{{ data['effect_id'] }}">ランキングへ</a></td>
-            </tr>
-            {% endfor %}
-        </table>
     </div>
-    <hr>
-
-    <hr>
-    <footer class="site-footer wrapper">
-        <div class="footer">
-        </div>
-    </footer>
-</body>
-</html>
+ {%- endblock %}

--- a/templates/myscore.html
+++ b/templates/myscore.html
@@ -1,35 +1,11 @@
-<!DOCTYPE html>
-<html lang="ja">
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="description" content="">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" media="screen and (max-width:768px)" href="{{ url_for('static', filename = 'css/sp-style.css') }}">
-    <link rel="stylesheet" media="screen and (min-width:769px)" href="{{ url_for('static', filename = 'css/style.css') }}">
-    <title>SDVX-EXスコアツール</title>
-</head>
-<body>
-    <header class="site-header wrapper">
-        <div class="header">
-            <a href="/" class="appname">SDVX-EXスコアツール</a>
-        </div>
-    </header>
-    <div class="myscore">
-        <p>レベルを選択してください。</p>
-        <br/>
+{%- extends "layout.html" %}
+{%- block content %}
+    <div id="myscore" class="container">
+        <h2 class="title">レベル選択</h2>
         <div class="level-inline">
             {% for i in range(20) %}
-            <a href="/myscore/{{ i + 1 }}" class="level-button">{{ i + 1 }}</a>
+            <a href="/myscore/{{ i + 1 }}" class="level-button btn btn-primary">{{ i + 1 }}</a>
             {% endfor %}
         </div>
     </div>
-    <hr>
-
-    <hr>
-    <footer class="site-footer wrapper">
-        <div class="footer">
-        </div>
-    </footer>
-</body>
-</html>
+{%- endblock %}


### PR DESCRIPTION
close #14

## スクリーンショット
### PC
- hiscore.html
<img width="1438" alt="スクリーンショット 2022-01-04 20 08 53" src="https://user-images.githubusercontent.com/40511624/148051867-b4839e38-23f4-415e-aa89-e815b224174f.png">

<img width="1438" alt="スクリーンショット 2022-01-04 20 15 02" src="https://user-images.githubusercontent.com/40511624/148051927-69f89650-f2c3-4d36-9a11-1618d6c2c598.png">

- myscore.html
<img width="1440" alt="スクリーンショット 2022-01-04 19 43 35" src="https://user-images.githubusercontent.com/40511624/148051658-39b6b249-9b6b-4f20-b84c-cce6311b69f7.png">

- level_myscore.html
<img width="1439" alt="スクリーンショット 2022-01-04 19 42 53" src="https://user-images.githubusercontent.com/40511624/148051711-b1212182-279f-4564-bc7a-d639192973a3.png">

### モバイル
- hiscore.html
<img width="377" alt="スクリーンショット 2022-01-04 20 09 17" src="https://user-images.githubusercontent.com/40511624/148051885-72a80fec-281f-4c56-a4f8-6ff0d1d7579e.png">

<img width="379" alt="スクリーンショット 2022-01-04 20 15 21" src="https://user-images.githubusercontent.com/40511624/148051904-a4750aa8-3354-4600-ac68-d20daa587032.png">

- myscore.html
<img width="376" alt="スクリーンショット 2022-01-04 19 43 47" src="https://user-images.githubusercontent.com/40511624/148051685-53e5228f-baae-4739-bd62-ecb0daae05b3.png">

- level_myscore.html
![ダウンロード](https://user-images.githubusercontent.com/40511624/148051841-105e66bf-1bdb-4447-9a6f-b1e8db71f8ab.gif)

## やったこと
- レイアウト変更
- 文面修正

## 確認してほしいこと
- [ ] reiyiyi さんのローカル環境で適切に表示されるか確認をお願いします。
- [ ] その他、レイアウトやコードに違和感や問題がないか確認をお願いします。